### PR TITLE
hotfix: ensure that Cuid2 uses an actual SHA-3 implementation

### DIFF
--- a/src/cuid.net/cuid.net.csproj
+++ b/src/cuid.net/cuid.net.csproj
@@ -33,6 +33,7 @@
     </PropertyGroup>
     
     <ItemGroup>
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/cuid.net/packages.lock.json
+++ b/src/cuid.net/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net6.0": {
+      "BouncyCastle.Cryptography": {
+        "type": "Direct",
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "pzHd/gZou2SG4tXQQwXt1oEVJ3ZpmHVa5/Hg0k9QMkdc84HEUBb2DI9ajRlw6TS6dTy/UPZXLjpV9Us5L0SeVA=="
+      },
       "Microsoft.CodeAnalysis.NetAnalyzers": {
         "type": "Direct",
         "requested": "[7.0.0, )",
@@ -30,6 +36,12 @@
       }
     },
     "net7.0": {
+      "BouncyCastle.Cryptography": {
+        "type": "Direct",
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "pzHd/gZou2SG4tXQQwXt1oEVJ3ZpmHVa5/Hg0k9QMkdc84HEUBb2DI9ajRlw6TS6dTy/UPZXLjpV9Us5L0SeVA=="
+      },
       "Microsoft.CodeAnalysis.NetAnalyzers": {
         "type": "Direct",
         "requested": "[7.0.0, )",

--- a/tests/cuid.net.benchmarks/packages.lock.json
+++ b/tests/cuid.net.benchmarks/packages.lock.json
@@ -27,6 +27,11 @@
         "resolved": "0.13.2",
         "contentHash": "+SGOYyXT6fiagbtrni38B8BqBgjruYKU3PfROI0lDIYo8jQ+APUmLKMEswK7zwR5fEOCrDmoAHSH6oykBkqPgA=="
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "pzHd/gZou2SG4tXQQwXt1oEVJ3ZpmHVa5/Hg0k9QMkdc84HEUBb2DI9ajRlw6TS6dTy/UPZXLjpV9Us5L0SeVA=="
+      },
       "CommandLineParser": {
         "type": "Transitive",
         "resolved": "2.4.3",
@@ -235,7 +240,10 @@
         "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "cuid.net": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "[2.0.0, )"
+        }
       }
     },
     "net7.0": {
@@ -264,6 +272,11 @@
         "resolved": "0.13.2",
         "contentHash": "+SGOYyXT6fiagbtrni38B8BqBgjruYKU3PfROI0lDIYo8jQ+APUmLKMEswK7zwR5fEOCrDmoAHSH6oykBkqPgA=="
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "pzHd/gZou2SG4tXQQwXt1oEVJ3ZpmHVa5/Hg0k9QMkdc84HEUBb2DI9ajRlw6TS6dTy/UPZXLjpV9Us5L0SeVA=="
+      },
       "CommandLineParser": {
         "type": "Transitive",
         "resolved": "2.4.3",
@@ -472,7 +485,10 @@
         "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "cuid.net": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "[2.0.0, )"
+        }
       }
     }
   }

--- a/tests/cuid.net.tests/packages.lock.json
+++ b/tests/cuid.net.tests/packages.lock.json
@@ -68,6 +68,11 @@
         "resolved": "0.1.0",
         "contentHash": "TYJwenjm6RTjs3hEphb4mL3h4jdSMWSvoRkuNRGXXD6ZcuMNWOR4UTzf6OGF+ReTYsE2c1Q3brLSD3cfIPjfdw=="
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "pzHd/gZou2SG4tXQQwXt1oEVJ3ZpmHVa5/Hg0k9QMkdc84HEUBb2DI9ajRlw6TS6dTy/UPZXLjpV9Us5L0SeVA=="
+      },
       "DiffEngine": {
         "type": "Transitive",
         "resolved": "11.0.0",
@@ -1123,7 +1128,10 @@
         }
       },
       "cuid.net": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "[2.0.0, )"
+        }
       }
     },
     "net7.0": {
@@ -1193,6 +1201,11 @@
         "resolved": "0.1.0",
         "contentHash": "TYJwenjm6RTjs3hEphb4mL3h4jdSMWSvoRkuNRGXXD6ZcuMNWOR4UTzf6OGF+ReTYsE2c1Q3brLSD3cfIPjfdw=="
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "pzHd/gZou2SG4tXQQwXt1oEVJ3ZpmHVa5/Hg0k9QMkdc84HEUBb2DI9ajRlw6TS6dTy/UPZXLjpV9Us5L0SeVA=="
+      },
       "DiffEngine": {
         "type": "Transitive",
         "resolved": "11.0.0",
@@ -2248,7 +2261,10 @@
         }
       },
       "cuid.net": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "[2.0.0, )"
+        }
       }
     }
   }


### PR DESCRIPTION
Resolves #12 

`Cuid2` was implemented using the `SHA512` class from .NET. The current implementation of .NET is only SHA-2 based rather than SHA-3 based. This hotfix addresses the issue by using BouncyCastle.

Signed-off-by: Alan Brault <alan.brault@visus.io>