### PR TITLE
refactor: align CUIDv2 generation with newest spec

### DIFF
--- a/src/cuid.net/Cuid.cs
+++ b/src/cuid.net/Cuid.cs
@@ -69,7 +69,7 @@ public readonly struct Cuid : IComparable, IComparable<Cuid>, IEquatable<Cuid>, 
 		{
 			_c = Counter.Instance.Value,
 			_f = Context.IdentityFingerprint,
-			_r = BinaryPrimitives.ReadUInt64LittleEndian(Utils.GenerateRandom(8, false)),
+			_r = BinaryPrimitives.ReadUInt64LittleEndian(Utils.GenerateRandom()),
 			_t = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
 		};
 

--- a/src/cuid.net/Cuid2.cs
+++ b/src/cuid.net/Cuid2.cs
@@ -2,7 +2,6 @@
 
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using Org.BouncyCastle.Crypto.Digests;
 
 /// <summary>
@@ -13,17 +12,17 @@ public readonly struct Cuid2 : IEquatable<Cuid2>
 {
 	private const int DefaultLength = 24;
 
-	private readonly ulong _c = Counter.Instance.Value;
+	private readonly ulong _counter = Counter.Instance.Value;
 
-	private readonly byte[] _f;
+	private readonly byte[] _fingerprint;
 
 	private readonly int _maxLength;
 
-	private readonly char _p;
+	private readonly char _prefix;
 
-	private readonly byte[] _r;
+	private readonly byte[] _random;
 
-	private readonly long _t;
+	private readonly long _timestamp;
 
 	/// <summary>
 	///     Initializes a new instance of the <see cref="Cuid2" /> structure.
@@ -54,10 +53,10 @@ public readonly struct Cuid2 : IEquatable<Cuid2>
 
 		_maxLength = maxLength;
 
-		_f = Context.IdentityFingerprint;
-		_p = Utils.GenerateCharacterPrefix();
-		_r = Utils.GenerateRandom(maxLength);
-		_t = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+		_fingerprint = Context.IdentityFingerprint;
+		_prefix = Utils.GenerateCharacterPrefix();
+		_random = Utils.GenerateRandom(maxLength);
+		_timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 	}
 
 	/// <summary>
@@ -85,11 +84,11 @@ public readonly struct Cuid2 : IEquatable<Cuid2>
 	/// <inheritdoc />
 	public bool Equals(Cuid2 other)
 	{
-		return _c == other._c &&
-		       _f.Equals(other._f) &&
-		       _p == other._p &&
-		       _r.Equals(other._r) &&
-		       _t == other._t;
+		return _counter == other._counter &&
+		       _fingerprint.Equals(other._fingerprint) &&
+		       _prefix == other._prefix &&
+		       _random.Equals(other._random) &&
+		       _timestamp == other._timestamp;
 	}
 
 	/// <inheritdoc />
@@ -101,7 +100,7 @@ public readonly struct Cuid2 : IEquatable<Cuid2>
 	/// <inheritdoc />
 	public override int GetHashCode()
 	{
-		return HashCode.Combine(_c, _f, _p, _r, _t);
+		return HashCode.Combine(_counter, _fingerprint, _prefix, _random, _timestamp);
 	}
 
 	/// <summary>
@@ -110,17 +109,17 @@ public readonly struct Cuid2 : IEquatable<Cuid2>
 	/// <returns>The value of this <see cref="Cuid2" />.</returns>
 	public override string ToString()
 	{
-		Span<byte> buffer = stackalloc byte[16];
+		Span<byte> data = stackalloc byte[16];
 		Span<byte> result = stackalloc byte[64];
-		
-		BinaryPrimitives.WriteInt64LittleEndian(buffer, _t);
-		BinaryPrimitives.WriteUInt64LittleEndian(buffer[..8], _c);
+
+		BinaryPrimitives.WriteInt64LittleEndian(data[..8], _timestamp);
+		BinaryPrimitives.WriteUInt64LittleEndian(data[^8..], _counter);
 
 		Sha3Digest digest = new(512);
-		
-		digest.BlockUpdate(buffer);
-		digest.BlockUpdate(_f);
-		digest.BlockUpdate(_r);
+
+		digest.BlockUpdate(data);
+		digest.BlockUpdate(_fingerprint);
+		digest.BlockUpdate(_random);
 
 		int bytesWritten = digest.DoFinal(result);
 
@@ -129,7 +128,7 @@ public readonly struct Cuid2 : IEquatable<Cuid2>
 			return string.Empty;
 		}
 
-		return _p + Utils.Encode(result.ToArray())[..( _maxLength - 1 )];
+		return _prefix + Utils.Encode(result.ToArray())[..( _maxLength - 1 )];
 	}
 
 	private static class Context

--- a/src/cuid.net/Fingerprint.cs
+++ b/src/cuid.net/Fingerprint.cs
@@ -2,7 +2,6 @@
 
 using System.Buffers.Binary;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Abstractions;
 using Extensions;
@@ -19,16 +18,23 @@ internal static class Fingerprint
 	private static byte[] GenerateIdentity()
 	{
 		byte[] identity = Encoding.UTF8.GetBytes(RetrieveSystemName());
-		
+
 		Span<byte> buffer = stackalloc byte[identity.Length + 40];
 
 		identity.CopyTo(buffer[..identity.Length]);
 
-		BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(identity.Length + 1, 4), Environment.ProcessId);
-		BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(identity.Length + 6, 4), Environment.CurrentManagedThreadId);
+		BinaryPrimitives.WriteInt32LittleEndian(
+			buffer.Slice(identity.Length + 1, 4),
+			Environment.ProcessId
+		);
+
+		BinaryPrimitives.WriteInt32LittleEndian(
+			buffer.Slice(identity.Length + 6, 4),
+			Environment.CurrentManagedThreadId
+		);
 
 		Utils.GenerateRandom(32).CopyTo(buffer[^32..]);
-		
+
 		return buffer.ToArray();
 	}
 
@@ -47,13 +53,13 @@ internal static class Fingerprint
 
 		return Encoding.UTF8.GetBytes(result);
 	}
-	
+
 	private static string GenerateSystemName()
 	{
 		byte[] bytes = Utils.GenerateRandom(32);
 		string hostname = Convert.ToHexString(bytes).ToUpperInvariant();
-		
-		return OperatingSystem.IsWindows() 
+
+		return OperatingSystem.IsWindows()
 			? hostname[..15] // windows hostnames are limited to 15 characters 
 			: hostname;
 	}

--- a/src/cuid.net/Fingerprint.cs
+++ b/src/cuid.net/Fingerprint.cs
@@ -18,28 +18,17 @@ internal static class Fingerprint
 
 	private static byte[] GenerateIdentity()
 	{
-		byte[] random = Utils.GenerateRandom(8, false);
-		byte[] system = Encoding.UTF8.GetBytes(RetrieveSystemName());
-		byte[] process = new byte[4];
-		byte[] thread = new byte[4];
+		byte[] identity = Encoding.UTF8.GetBytes(RetrieveSystemName());
+		
+		Span<byte> buffer = stackalloc byte[identity.Length + 40];
 
-		Span<byte> buffer = stackalloc byte[random.Length + system.Length + process.Length + thread.Length];
+		identity.CopyTo(buffer[..identity.Length]);
 
-		if ( !BinaryPrimitives.TryWriteInt32LittleEndian(process, Environment.ProcessId) )
-		{
-			Array.Copy(Utils.GenerateRandom(4, false), process, 4);
-		}
+		BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(identity.Length + 1, 4), Environment.ProcessId);
+		BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(identity.Length + 6, 4), Environment.CurrentManagedThreadId);
 
-		if ( !BinaryPrimitives.TryWriteInt32LittleEndian(thread, Environment.CurrentManagedThreadId) )
-		{
-			Array.Copy(Utils.GenerateRandom(4, false), thread, 4);
-		}
-
-		random.CopyTo(buffer[..random.Length]);
-		system.CopyTo(buffer.Slice(random.Length + 1, system.Length));
-		process.CopyTo(buffer.Slice(random.Length + system.Length + 2, process.Length));
-		thread.CopyTo(buffer[^thread.Length..]);
-
+		Utils.GenerateRandom(32).CopyTo(buffer[^32..]);
+		
 		return buffer.ToArray();
 	}
 
@@ -58,12 +47,15 @@ internal static class Fingerprint
 
 		return Encoding.UTF8.GetBytes(result);
 	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	
 	private static string GenerateSystemName()
 	{
-		byte[] bytes = Utils.GenerateRandom(24, false);
-		return Convert.ToHexString(bytes).ToUpperInvariant()[..15];
+		byte[] bytes = Utils.GenerateRandom(32);
+		string hostname = Convert.ToHexString(bytes).ToUpperInvariant();
+		
+		return OperatingSystem.IsWindows() 
+			? hostname[..15] // windows hostnames are limited to 15 characters 
+			: hostname;
 	}
 
 	private static string RetrieveSystemName()


### PR DESCRIPTION
Refactors code base to align it with the current CUIDv2 implementation. The following overall changes have occurred:

- Private struct fields have been renamed to be more contextually accurate (e.g., `_c` -> `_counter`)
- Calls to the insecure `System.Random` have been removed from `Utils.GenerateRandom()`
- Implementation of `Utils.GenerateIdentity()` has been refactored to use only the following parts:
   - System Hostname (if unavailable, a base-16 value is generated)
   - Process ID
   - Thread ID
   - 32 bytes of secure random data are generated via `Utils.GenerateRandom()`
- Counter in `Cuid2.Counter` was refactored:
   - Value changed from `unsigned int` to `unsigned long`
   - Initialization of the seed value now includes multiplication against the value `476782367`